### PR TITLE
add stm32l4r5 to otg_fs feature list

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,7 @@ pub mod lptimer;
         feature = "stm32l486",
         feature = "stm32l496",
         feature = "stm32l4a6",
+        feature = "stm32l4r5",
     )
 ))]
 pub mod otg_fs;


### PR DESCRIPTION
needed for the USB example. I'll create a pull request to your example project.